### PR TITLE
chore: Dropped support for Node 12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
BREAKING CHANGE: Dropped support for Node 12