### PR TITLE
refactor: updated lock file version check to use new workflow

### DIFF
--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   version-check:
-    uses: openedx/.github/.github/workflows/lockfileversion-check-v3.yml@master
+    uses: openedx/.github/.github/workflows/lockfile-check.yml@master

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edx/edx-proctoring": "^4.9.0"
+        "@edx/edx-proctoring": "^4.16.1"
       }
     },
     "node_modules/@edx/edx-proctoring": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@edx/edx-proctoring/-/edx-proctoring-4.15.0.tgz",
-      "integrity": "sha512-MgLwaaBLMnK6+h6vxA/Jx2vbXRLvC1amEAIUyzCmH6q2j/Ug7oAeOieMwhp5WNh9xecVO/l9y/gHTSrw+OiUmg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@edx/edx-proctoring/-/edx-proctoring-4.16.1.tgz",
+      "integrity": "sha512-9Bhg3tWN0auYz9390RuX0+TLkUKbmIzPPv9byIqoCrMdPucgN8JidzSEZ2l4LKlromQZNC3op0KQELF1MW3Enw==",
       "hasShrinkwrap": true
     },
     "node_modules/@edx/edx-proctoring/node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edx/edx-proctoring": "^4.16.1"
+        "@edx/edx-proctoring": "4.16.1"
       }
     },
     "node_modules/@edx/edx-proctoring": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/openedx/mockprock#readme",
   "dependencies": {
-    "@edx/edx-proctoring": "^4.16.1"
+    "@edx/edx-proctoring": "4.16.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://github.com/openedx/mockprock#readme",
   "dependencies": {
-    "@edx/edx-proctoring": "^4.9.0"
+    "@edx/edx-proctoring": "^4.16.1"
   }
 }


### PR DESCRIPTION
Renamed `lockfileversion-check-v3` to `lockfile-check` in lockfile version file.
# Ticket

[Prototype a way to review NPM lockfiles in PRs](https://github.com/edx/edx-arch-experiments/issues/355)