### PR TITLE
fix: trigger release workflow on push to master instead of tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release CI
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - master
 
 permissions:
   id-token: write  # Required for OIDC


### PR DESCRIPTION
## Summary

- Change `release.yml` trigger from `push: tags: '*'` to `push: branches: [master]`

`npx semantic-release` decides internally whether to cut a new release based on commit history since the last tag. It should run on every push to `master` (i.e., every merged PR) — a tag-push trigger is never fired by the workflow itself, so the release job never ran.

Related: #66

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)